### PR TITLE
Add envvar to allow upgrading pip before installing default-python-packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,14 @@ pipenv
 ```
 
 You can specify a non-default location of this file by setting a `ASDF_PYTHON_DEFAULT_PACKAGES_FILE` variable.
+
+### Upgrade pip before installing Default Python packages
+
+In some cases (older verisons of pip - which come with older versions of Python) unpinned package versions in `$HOME/.default-python-packages` (or `ASDF_PYTHON_DEFAULT_PACKAGES_FILE` environment variable) may cause errors during pip install - due to latest package dependency versions not being available.
+
+You can set the environment variable `ASDF_PYTHON_PKGS_UPGRADE_PIP_FIRST` (to any value) to first upgrade your pip version, before installing pacakges from `$HOME/.default-python-packages` (or `ASDF_PYTHON_DEFAULT_PACKAGES_FILE` environment variable):
+
+```
+export ASDF_PYTHON_PKGS_UPGRADE_PIP_FIRST="true"
+asdf install python 3.6.15
+```

--- a/bin/install
+++ b/bin/install
@@ -34,6 +34,10 @@ install_default_python_packages() {
   local packages_file="${ASDF_PYTHON_DEFAULT_PACKAGES_FILE:-$HOME/.default-python-packages}"
 
   if [ -f "$packages_file" ]; then
+    if [[ -n "${ASDF_PYTHON_PKGS_UPGRADE_PIP_FIRST:-}" ]]; then
+        echo "pip install --upgrade pip"
+        PATH="$ASDF_INSTALL_PATH/bin:$PATH" pip install --upgrade pip
+    fi
     echo -ne "\nInstalling default python packages..."
     PATH="$ASDF_INSTALL_PATH/bin:$PATH" pip install -U -r "$packages_file"
   fi


### PR DESCRIPTION
# Feature
Upgrade pip before running `pip install` for `default-python-packages`

```
$ cat ~/.default-python-packages
ansible
```

Problem:
```sh
$ asdf install python 3.6.15
# ...
# Python 3.6.15 install goes here
# ...
# some other pip packages collected first
# ...
Collecting ansible-core~=2.16.0 (from ansible->-r /home/ddastoor/.default-python-packages (line 4))
Could not find a version that satisfies the requirement ansible-core~=2.16.0 (from ansible->-r /home/ddastoor/.default-python-packages (line 4)) (from versions: 0.0.1a1, 2.11.0b1, 2.11.0b2, 2.11.0b3, 2.11.0b4, 2.11.0rc1, 2.11.0rc2, 2.11.0, 2.11.1rc1, 2.11.1, 2.11.2rc1, 2.11.2, 2.11.3rc1, 2.11.3, 2.11.4rc1, 2.11.4, 2.11.5rc1, 2.11.5, 2.11.6rc1, 2.11.6, 2.11.7rc1, 2.11.7, 2.11.8rc1, 2.11.8, 2.11.9rc1, 2.11.9, 2.11.10rc1, 2.11.10, 2.11.11rc1, 2.11.11, 2.11.12rc1, 2.11.12)
No matching distribution found for ansible-core~=2.16.0 (from ansible->-r /home/ddastoor/.default-python-packages (line 4))
You are using pip version 18.1, however version 21.3.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
```

Solution:
```sh
$ asdf install python 3.6.15
# ...
# Python 3.6.15 install goes here
# ...
Installed Python-3.6.15 to /home/ddastoor/.asdf/installs/python/3.6.15
pip install --upgrade pip
Collecting pip
Using cached https://files.pythonhosted.org/packages/a4/6d/6463d49a933f547439d6b5b98b46af8742cc03ae83543e4d7688c2420f8b/pip-21.3.1-py3-none-any.whl
Installing collected packages: pip
Found existing installation: pip 18.1
Uninstalling pip-18.1:
Successfully uninstalled pip-18.1
Successfully installed pip-21.3.1
# ...
# some other pip packages collected first
# ...
Collecting ansible-core~=2.11.7
Using cached ansible-core-2.11.12.tar.gz (7.1 MB)
Preparing metadata (setup.py) ... done
```