### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Python plugin for [asdf](https://github.com/asdf-vm/asdf) version manager
 ## Install
 
 ```
-asdf plugin-add python
+asdf plugin add python
 ```
 
 ### Install with `--patch`

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Python plugin for [asdf](https://github.com/asdf-vm/asdf) version manager
 ## Install
 
 ```
-asdf plugin add python
+asdf plugin add python https://github.com/asdf-community/asdf-python.git
 ```
 
 ### Install with `--patch`


### PR DESCRIPTION
Small syntax error. 
The example command is "asdf plugin-add python", but the correct one is "asdf plugin add python", without a hyphen. 
Tested on Fedora.