### PR TITLE
Update asdf commands with 0.16+ versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,13 @@ Python plugin for [asdf](https://github.com/asdf-vm/asdf) version manager
 ## Install
 
 ```
-asdf plugin-add python
+asdf plugin add python https://github.com/asdf-community/asdf-python.git
+```
+
+For pre-0.16.0 asdf versions:
+
+```
+asdf plugin-add python https://github.com/asdf-community/asdf-python.git
 ```
 
 ### Install with `--patch`
@@ -37,6 +43,12 @@ during installation of python versions. You may also want to check [Python's off
 
 A common request for Python is being able to use the `python2` and `python3` commands without needing to switch version.
 This can be achieved by setting multiple versions of Python, for example with
+
+```
+asdf set python -u 3.6.2 2.7.13
+```
+
+For pre-0.16.0 asdf versions:
 
 ```
 asdf global python 3.6.2 2.7.13


### PR DESCRIPTION
This PR updates the commands in README.md with asdf 0.16+ versions since they are different.

PS: I haven't tested out setting 2 versions with `asdf set -u python 3.13.2 2.7.18`, so not sure whether it links python3 and python2 like before. (Haven't needed to use python2 personally, would be great if someone could validate it)

Ref:
- https://asdf-vm.com/guide/upgrading-to-v0-16.html
- Continuation from https://github.com/asdf-community/asdf-python/pull/198