### PR TITLE
Doc: Move -u flag to correct place in asdf set

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ A common request for Python is being able to use the `python2` and `python3` com
 This can be achieved by setting multiple versions of Python, for example with
 
 ```
-asdf set python -u 3.6.2 2.7.13
+asdf set -u python 3.6.2 2.7.13
 ```
 
 For pre-0.16.0 asdf versions:


### PR DESCRIPTION
The `-u` flag for `asdf set` must be before the package, somehow I wrote the correct command in PR body but left incorrect one in README, silly me.

- `-u` sets this for `$HOME/.tool-versions`
- Run without `-u` for `$PWD/.tool-versions`

Ref:
- Fixes wrong command from: https://github.com/asdf-community/asdf-python/pull/205
- Read more: https://asdf-vm.com/guide/getting-started.html#_6-set-a-version